### PR TITLE
Add script create-assigned-issue

### DIFF
--- a/create-assigned-issue.rb
+++ b/create-assigned-issue.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+banner = <<-BANNER
+Usage: create-assigned-issue.rb <issue URL>
+  * Copies issue as template
+  * Replaces any references to the assigned user (eg, at-mentions, etc.)
+  * Also "undoes" any checkboxes in issue template (eg, [x] -> [ ])
+  * For each collaborator of repo, creates a new issue, assigned to collaborator
+BANNER
+
+$stderr.sync = true
+require 'octokit'
+require 'optparse'
+
+file      = __FILE__
+issue_url = ARGV.first
+token     = ENV['TOKEN']
+
+abort banner unless issue_url || issue_url == '-h'
+
+REGEX = %r{github\.com/([^/]+/[^/]+)/issues/(\d+)}
+# https://github.com/username/reponame/issues/2
+# -> username/reponame, 2
+def parse_issue_url(url)
+  if md = REGEX.match(url)
+    [md[1], md[2]]
+  end
+end
+
+Octokit.auto_paginate = true
+
+client       = Octokit::Client.new :access_token => ENV['TOKEN']
+repo, number = parse_issue_url(issue_url)
+issue        = client.issue(repo, number)
+assigned     = issue.assignee.login
+template     = issue.body.gsub("[x] ", "[ ] ")
+template     = template.gsub("#{assigned}", "%{assignee}")
+title        = issue.title
+title        = title.gsub("#{assigned}", "%{assignee}")
+
+client.collaborators(repo).each do |collaborator|
+  next if assigned == collaborator[:login]
+  title    = title % { assignee: collaborator[:login] }
+  body     = template % { assignee: collaborator[:login] }
+  assignee = collaborator[:login]
+
+  puts "Creating assigned issue for @#{collaborator[:login]}"
+  client.create_issue repo, title, body, assignee: assignee
+end

--- a/create-assigned-issue.rb
+++ b/create-assigned-issue.rb
@@ -15,7 +15,7 @@ file      = __FILE__
 issue_url = ARGV.first
 token     = ENV['TOKEN']
 
-abort banner unless issue_url || issue_url == '-h'
+abort banner if !issue_url || issue_url == '-h'
 
 REGEX = %r{github\.com/([^/]+/[^/]+)/issues/(\d+)}
 # https://github.com/username/reponame/issues/2

--- a/create-assigned-issue.rb
+++ b/create-assigned-issue.rb
@@ -28,7 +28,7 @@ end
 
 Octokit.auto_paginate = true
 
-client       = Octokit::Client.new :access_token => ENV['TOKEN']
+client       = Octokit::Client.new :access_token => ENV['GITHUBTEACHER_TOKEN']
 repo, number = parse_issue_url(issue_url)
 issue        = client.issue(repo, number)
 assigned     = issue.assignee.login


### PR DESCRIPTION
This is intended as a companion to [add-collaborators](https://github.com/jaw6/training-utils/blob/a8042c751b41f4d9dab86981da573fe2c776fd2e/add-collaborators.rb).

The idea is that this might be used, during class, to create & assign an issue per student, based on a target/template issue.

So: point `create-assigned-issue` at an issue. This issue becomes the "template". The script will create new issues, one for each repo collaborator, based on the template. Any done todo items will be undone, and any references within the template to its assigned user will be rewritten for the newly assigned user.

I'm thinking that the template would be an issue we create and assign to @githubstudent. So, any references inside that issue to `@githubstudent` (or `githubstudent`) will be re-written. Here's an example of how this might work:
### Target/template issue:

**Title:** Create bio for githubstudent
**Body:**

```
* [x] Create new branch called githubstudent
* [x] Add a new file githubstudent.md
* [x] Create a pull request, referencing this issue by number
* [x] At-mention @githubteacher
```

**Assigned:** @githubstudent
### Turns into:

**Title:** Create bio for jaw6
**Body:**

```
* [ ] Create new branch called jaw6
* [ ] Add a new file jaw6.md
* [ ] Create a pull request, referencing this issue by number
* [ ] At-mention @githubteacher
```

**Assigned:** @jaw6

---

Thoughts? Ideas? Questions? Feedback?
