### PR TITLE
`add-collaborators` tweaks

### DIFF
--- a/add-collaborators
+++ b/add-collaborators
@@ -38,10 +38,16 @@ puts({repo_name: repo_name, issue_num: issue_num}.inspect)
 Octokit.auto_paginate = true
 client = Octokit::Client.new :access_token => access_token
 
+# Save a little time - build a hash of current collaborators so we can skip them later
+current_collaborators = Hash[client.collaborators(repo_name).map { |collaborator|
+  [collaborator[:login], collaborator[:login]]
+}]
+
 # Get Issue Commenters and Add as Collaborators
 begin
   client.issue_comments(repo_name, issue_num).each do |comment|
     username = comment[:user][:login]
+    next if current_collaborators[username] # skip adding if already a collaborator
     user_added = client.add_collaborator(repo_name, username)
     if !user_added
       puts "Failed to add #{username} as a collaborator"

--- a/add-collaborators
+++ b/add-collaborators
@@ -44,19 +44,29 @@ current_collaborators = Hash[client.collaborators(repo_name).map { |collaborator
 }]
 
 # Get Issue Commenters and Add as Collaborators
+successfully_added_users = []
 begin
   client.issue_comments(repo_name, issue_num).each do |comment|
     username = comment[:user][:login]
     next if current_collaborators[username] # skip adding if already a collaborator
-    user_added = client.add_collaborator(repo_name, username)
-    if !user_added
-      puts "Failed to add #{username} as a collaborator"
+    if user_added = client.add_collaborator(repo_name, username)
+      successfully_added_users << username
+    else
+      puts "Failed to add #{username} as a collaborator (check: is githubteacher repository owner?)"
     end
   end
 rescue Octokit::NotFound
   puts "[404] - Repository not found:\nIf #{repo_name || "nil"} is correct, are you using the right Auth token?"
-
 rescue Octokit::UnprocessableEntity
   puts "[422] - Unprocessable Entity:\nAre you trying to add collaborators to an org-level repository?"
+end
 
+if successfully_added_users.any?
+  begin
+    verb = successfully_added_users.size == 1 ? "is" : "are"
+    message = ":tada: #{successfully_added_users.map { |name| "@#{name}" }.join(" ")} #{verb} now repository collaborator#{successfully_added_users.size == 1 ? '' : 's'} :balloon:"
+    client.add_comment repo_name, issue_num, message
+  rescue => e
+    abort "ERR posting comment (#{e.inspect})"
+  end
 end

--- a/add-collaborators
+++ b/add-collaborators
@@ -56,9 +56,9 @@ begin
     end
   end
 rescue Octokit::NotFound
-  puts "[404] - Repository not found:\nIf #{repo_name || "nil"} is correct, are you using the right Auth token?"
+  abort "[404] - Repository not found:\nIf #{repo_name || "nil"} is correct, are you using the right Auth token?"
 rescue Octokit::UnprocessableEntity
-  puts "[422] - Unprocessable Entity:\nAre you trying to add collaborators to an org-level repository?"
+  abort "[422] - Unprocessable Entity:\nAre you trying to add collaborators to an org-level repository?"
 end
 
 if successfully_added_users.any?

--- a/add-collaborators
+++ b/add-collaborators
@@ -63,8 +63,25 @@ end
 
 if successfully_added_users.any?
   begin
-    verb = successfully_added_users.size == 1 ? "is" : "are"
-    message = ":tada: #{successfully_added_users.map { |name| "@#{name}" }.join(" ")} #{verb} now repository collaborator#{successfully_added_users.size == 1 ? '' : 's'} :balloon:"
+    names = "@#{successfully_added_users.first}"
+    verb  = "is"
+    num   = "a"
+    noun  = "collaborator"
+    
+    if successfully_added_users.size > 1
+      verb  = "are"
+      num   = ""
+      noun  = "collaborators"
+      
+      if successfully_added_users.size == 2
+        names = "@#{successfully_added_users.first} and @#{successfully_added_users.last}"
+      else
+        at_mentions = successfully_added_users.map { |name| "@#{name}" }
+        names = "#{at_mentions[0...-1].join(", ")}, and #{at_mentions[-1]}"
+      end
+    end
+    
+    message = ":tada: #{names} #{verb} now #{num} repository #{noun}. :balloon:"
     client.add_comment repo_name, issue_num, message
   rescue => e
     abort "ERR posting comment (#{e.inspect})"


### PR DESCRIPTION
A couple of tweaks to `add-collaborators` after using it in a particularly busy class last week:
- Grabs a hash of current collaborators before working through issue comments: skips anyone who is already a collaborator
  - Old version would still `post` to the collaborators API for _every_ comment in the issue
  - If there are 100s of comments, this should be considerably faster
- Posts a comment as teacher at the end of the script with `foo, bar, baz are now repository collaborators`
  - should cut down on student confusion - they should now get a notification & see a comment when they've been added
- One or two other minor things while I was in there. (mostly `abort` instead of just `puts` on error...)

@loranallensmith @brntbeer @patrickmckenna any feedback here? I've done some testing and confirmed it "works on my machine" -- got a minute to try this out?
