### PR TITLE
Automate repo setup

### DIFF
--- a/new-training-class
+++ b/new-training-class
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require_relative 'training-class'
+
+tc = TrainingClass.new('acme', 'developers')
+tc.create_repo
+tc.set_up_team
+tc.add_students_to_team ['githubstudent']

--- a/training-class.rb
+++ b/training-class.rb
@@ -15,8 +15,8 @@ class TrainingClass
     @client = Octokit::Client.new :access_token => access_token
   end
 
-  def create_repo
-    repo_name = @customer + '-' + Date.today.to_s + '-' + @class_name
+  def create_repo(repo_name = nil)
+    repo_name ||= @customer + '-' + Date.today.to_s + '-' + @class_name
     repo_full_name = @@org + '/' + repo_name
     if @client.repository?(repo_full_name)
       puts "A repo named #{repo_full_name} already exists!"
@@ -30,8 +30,8 @@ class TrainingClass
      end
   end
 
-  def set_up_team
-    team_name = 'team-' + @repo['name']
+  def set_up_team(team_name = nil)
+    team_name ||= 'team-' + @repo['name']
     org_teams = @client.org_teams(@@org).freeze
     team_index = org_teams.index { |team| team['name'] == team_name }
     if team_index
@@ -49,7 +49,7 @@ class TrainingClass
     end
   end
 
-  def add_students_to_team(students)
+  def add_students_to_team(students = [])
     students << 'githubteacher'
     students.each do |student|
       @client.add_team_membership(@team['id'],

--- a/training-class.rb
+++ b/training-class.rb
@@ -1,0 +1,48 @@
+require 'octokit'
+require 'date'
+
+class TrainingClass
+  attr_reader :customer, :class_name, :repo, :team
+  
+  def initialize(customer, class_name)
+    @@token_error_message='Error: no environment variable called GITHUBTEACHER_TOKEN!'.freeze
+    @@org = 'githubschool'.freeze
+    @customer = customer.freeze
+    @class_name = class_name.freeze
+    @repo = nil
+    @team = nil
+    access_token = ENV['GITHUBTEACHER_TOKEN'].freeze or abort(@@token_error_message)
+    @client = Octokit::Client.new :access_token => access_token
+  end
+
+  def create_repo
+    repo_name = @customer + '-' + Date.today.to_s + '-' + @class_name
+    @repo = @client.repository(@@org + '/' + repo_name)
+    if !@repo
+       @repo = @client.create_repository(repo_name,
+        :organization => @@org,
+        :has_issues => true,
+        :has_wiki => false,
+        :auto_init => true)
+     end
+  end
+
+  def set_up_team
+    team_name = 'team-' + @repo['name']
+    @team = @client.create_team(@@org,
+      :name => team_name) unless @client.org_teams(@@org).include?(team_name)
+    repo_added_to_team = @client.add_team_repo(@team['id'],
+      @repo['full_name'],
+      :permission => 'push',
+      :accept => 'application/vnd.github.ironman-preview+json')
+  end
+
+  def add_students_to_team(students)
+    students << 'githubteacher'
+    students.each do |student|
+      @client.add_team_membership(@team['id'],
+        student)
+    end
+  end
+
+end


### PR DESCRIPTION
@github/training-teachers Here's some very rough work related to github/services#1276; it should resolve github/services#932.
### Currently Desired Functionality (may change)
- [x] automatically create a new (private?) repo in the `githubschool` org (using some [agreed upon naming convention](https://github.com/github/services/issues/1276)?)
- [ ] seed that repo with a template `README`
- [x] create a new, secret team in the `githubschool` org, with access to only the above repo
- [ ] automatically add students to that team (pulling data from X?)
