### PR TITLE
Record dependencies and provide install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-pinboard-backup-matthew.sh
-pinboard-backup-matthew
+/.bundle/
+/vendor/gems

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.0.0)
+    octokit (4.2.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is a package of git- and github-training scripts into an easily-installed p
 
 ## Installation
 
-If you have Ruby installed, you can install these scripts into a directory in your path by running:
+If you have Ruby >= 1.9 installed, you can install these scripts into a directory in your `$PATH` by running:
 
 ```
-$ rake
+$ script/bootstrap
 ```
 
 ## Usage

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :install do
 end
 
 def ask_for_target_dir
-  puts "Directory to install? (needs to be in your $PATH, /usr/local/bin is the default) "
+  puts "Directory to install? (needs to be in your $PATH; /usr/local/bin is the default, hit enter to use that)"
   answer = STDIN.gets.chomp
   (answer unless answer == "") || "/usr/local/bin"
 end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# resolves all dependencies that the application requires to run
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# make sure bundler installed
+which bundler 2>&1 >/dev/null || gem install bundler
+
+# make sure needed gems installed
+bundle check --path vendor/gems 2>&1 >/dev/null || bundle install --path vendor/gems --quiet
+
+# install scripts
+rake


### PR DESCRIPTION
Resolves #8.

@github/training-teachers How pedantic should we make these? For instance, should we check to make sure Ruby is installed? Should we check that a user-specified install directory is actually in their `$PATH`?

This is a deliberately simple approach right now. What am I missing? Anything you'd like to see changed?
