### PR TITLE
Add additional folders/files to excludes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'fileutils'
 task default: :install
 
 task :install do
-  scripts = Dir['*'] - %w{LICENSE.txt Rakefile README.md}
+  scripts = Dir['*'] - %w{script vendor common.rb Gemfile Gemfile.lock LICENSE.txt Rakefile README.md}
   target  = ENV["TARGET"] || ask_for_target_dir
   File.directory?(File.expand_path(target)) or abort("Install directory isn't a directory")
 


### PR DESCRIPTION
`script/`, `vendor/`, `common.rb`, `Gemfile` and `Gemfile.lock` should not be symlinked when running `script/bootstrap`.

@github/training-teachers can I get your 👀  on this, please.
