### PR TITLE
Specify file encoding when transposing CSVs

### DIFF
--- a/transpose
+++ b/transpose
@@ -28,7 +28,7 @@ fi
 _outputfile="${_inputfile%%.*}-transposed.csv"
 # _outputfile="${_inputfile%%.*}-`date +%Y-%m-%d`.csv"
 
-"${_transpose}" "${_inputfile}" > "${_outputfile}"
+"${_transpose}" "${_inputfile}"
 
 echo "SUCCESS: '${_outputfile}' created"
 exit 0

--- a/transpose
+++ b/transpose
@@ -28,7 +28,7 @@ fi
 _outputfile="${_inputfile%%.*}-transposed.csv"
 # _outputfile="${_inputfile%%.*}-`date +%Y-%m-%d`.csv"
 
-cat "${_inputfile}" | "${_transpose}" > "${_outputfile}"
+"${_transpose}" "${_inputfile}" > "${_outputfile}"
 
 echo "SUCCESS: '${_outputfile}' created"
 exit 0

--- a/transpose-csv.rb
+++ b/transpose-csv.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require 'CSV'
 
+file = File.open(ARGV[0], "r:ISO-8859-1:ISO-8859-1")
+rows = CSV.parse(file)
+
 # Via https://stackoverflow.com/questions/29521170/ruby-transpose-csv
-rows = CSV.new($stdin).read
 puts rows.transpose.map { |x| x.join ',' }

--- a/transpose-csv.rb
+++ b/transpose-csv.rb
@@ -1,8 +1,18 @@
 #!/usr/bin/env ruby
 require 'CSV'
 
-file = File.open(ARGV[0], "r:ISO-8859-1:ISO-8859-1")
+def get_dest(src)
+    dest = src.split('.')
+    dest[0] += '-transposed'
+    dest.join('.')
+end
+
+src = ARGV[0]
+file = File.open(src, "r:ISO-8859-1")
 rows = CSV.parse(file)
 
-# Via https://stackoverflow.com/questions/29521170/ruby-transpose-csv
-puts rows.transpose.map { |x| x.join ',' }
+CSV.open(get_dest(src), "wb") do |csv|
+    rows.transpose.each do |row|
+        csv << row
+    end
+end


### PR DESCRIPTION
This PR specifies the CSV encoding correctly as `ISO-8859-1` when transposing with `transpose` / `transpose-csv.rb`.
