### PR TITLE
Added instructions for setting up the **bash** shell

### DIFF
--- a/historytailbash
+++ b/historytailbash
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Add the following 2 lines to your ~/.bashrc file to tell bash to save your history
+# to the history file after each command rather than after shell exit
+#
+# shopt -s histappend
+# PROMPT_COMMAND="history -a;$PROMPT_COMMAND"
+#
+
 #Ensure we have the quantity specified on the CLI
 if [ -z "$2" ]; then ARG_ERR=ERR; fi
 if [ -z "$1" ]; then ARG_ERR=ERR; fi


### PR DESCRIPTION
Discovered that the **default** install of the bash shell on Windows did not work with this script.
Adding the lines indicated in the change comment lines to the ~/.bashrc file instructs **bash** to save every command to the ~/.bash_history file when they are executed, the default behavior is to save the instructions to the history file only on exit of the shell.

Closes #20 